### PR TITLE
Update Example & Make it easier to get started with

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,21 @@ When your device boots, the output should look like the following, watch careful
 [Dec 25 13:25:24.986] mgos_i2c_create      I2C GPIO init ok (SDA: 23, SCL: 22)
 [Dec 25 13:25:24.992] mg_rpc_channel_uart  0x3ffbc478 UART0
 [Dec 25 13:25:25.001] mgos_init            Init done, RAM: 317608 total, 275252 free, 275252 min free
-[Dec 25 13:25:25.098] ====================== Starting ============================= 
+[Dec 25 13:25:25.098] ====================== Starting =============================
 [Dec 25 13:25:25.424] mongoose_poll        New heap free LWM: 261716
-[Dec 25 13:25:27.426] Temperature: 22.960000 *C 
-[Dec 25 13:25:27.433] Humidity: 43.640000 %RH 
-[Dec 25 13:25:27.442] Pressure: 1025.687700 hPa 
-[Dec 25 13:25:29.426] Temperature: 22.970000 *C 
-[Dec 25 13:25:29.433] Humidity: 43.640000 %RH 
-[Dec 25 13:25:29.441] Pressure: 1025.714100 hPa 
-[Dec 25 13:25:31.425] Temperature: 22.960000 *C 
-[Dec 25 13:25:31.433] Humidity: 43.650000 %RH 
-[Dec 25 13:25:31.441] Pressure: 1025.692000 hPa 
+[Dec 25 13:25:27.426] Temperature: 22.960000 *C
+[Dec 25 13:25:27.433] Humidity: 43.640000 %RH
+[Dec 25 13:25:27.442] Pressure: 1025.687700 hPa
+[Dec 25 13:25:29.426] Temperature: 22.970000 *C
+[Dec 25 13:25:29.433] Humidity: 43.640000 %RH
+[Dec 25 13:25:29.441] Pressure: 1025.714100 hPa
+[Dec 25 13:25:31.425] Temperature: 22.960000 *C
+[Dec 25 13:25:31.433] Humidity: 43.650000 %RH
+[Dec 25 13:25:31.441] Pressure: 1025.692000 hPa
 ```
 
 Please note that on ESP8266 and ESP32 the pins you choose to use for I2C aren't important, just ensure your configuration is on the pins you've selected.
+
+It is well known that BME280's tend to self-warm and report higher than expected temperatures.  The tolerance of the BME280 tensor is +/-1C, however when added to heating it isn't uncommon to see temperatures as much as 1.8C higher than ambient.  You should add adjustments to your code after testing in the environment you will use the sensor using a reliable thermometer.  Please do not report excessive temps as a Mongoose bug.
+
+Tested using Adafruit BME280 and Adafruit Huzzah32 (Pins 22 and 23).

--- a/README.md
+++ b/README.md
@@ -12,3 +12,56 @@ This app is a BME280 sensor usage usage example in JavaScript.
 <p align="center">
   <img src="https://mongoose-os.com/images/app1.gif" width="75%">
 </p>
+
+Alternatively, you can build and flash this example from the command line:
+
+```
+### Build
+$ git clone https://github.com/mongoose-os-apps/example-arduino-adafruit-bme280-js.git && cd example-arduino-adafruit-bme280-js
+$ mos build --platform esp32
+$ mos flash
+
+### Wait for Boot and then set I2C Pins
+$ mos console
+$ mos config-set i2c.scl_gpio=22 i2c.sda_gpio=23
+
+### Verify I2C
+$ mos config-get i2c
+```
+
+## Using this Example
+
+For this example to work properly you must ensure your I2C or SPI configuration is correct.  You can check your device's current configuration using `mos config-get`, look for the "i2c" or "spi" section.  
+
+```
+$ mos config-get i2c
+Using port /dev/ttyUSB1
+{
+  "debug": false,
+  "enable": true,
+  "freq": 100000,
+  "scl_gpio": 22,
+  "sda_gpio": 23
+}
+```
+
+When your device boots, the output should look like the following, watch carefully for the "mgos_i2c_create" (or equivilent SPI) line from the boot up messages to ensure your pins were initialized correctly via the Web UI or `mos console`:
+
+```
+[Dec 25 13:25:24.986] mgos_i2c_create      I2C GPIO init ok (SDA: 23, SCL: 22)
+[Dec 25 13:25:24.992] mg_rpc_channel_uart  0x3ffbc478 UART0
+[Dec 25 13:25:25.001] mgos_init            Init done, RAM: 317608 total, 275252 free, 275252 min free
+[Dec 25 13:25:25.098] ====================== Starting ============================= 
+[Dec 25 13:25:25.424] mongoose_poll        New heap free LWM: 261716
+[Dec 25 13:25:27.426] Temperature: 22.960000 *C 
+[Dec 25 13:25:27.433] Humidity: 43.640000 %RH 
+[Dec 25 13:25:27.442] Pressure: 1025.687700 hPa 
+[Dec 25 13:25:29.426] Temperature: 22.970000 *C 
+[Dec 25 13:25:29.433] Humidity: 43.640000 %RH 
+[Dec 25 13:25:29.441] Pressure: 1025.714100 hPa 
+[Dec 25 13:25:31.425] Temperature: 22.960000 *C 
+[Dec 25 13:25:31.433] Humidity: 43.650000 %RH 
+[Dec 25 13:25:31.441] Pressure: 1025.692000 hPa 
+```
+
+Please note that on ESP8266 and ESP32 the pins you choose to use for I2C aren't important, just ensure your configuration is on the pins you've selected.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ When your device boots, the output should look like the following, watch careful
 
 Please note that on ESP8266 and ESP32 the pins you choose to use for I2C aren't important, just ensure your configuration is on the pins you've selected.
 
-It is well known that BME280's tend to self-warm and report higher than expected temperatures.  The tolerance of the BME280 tensor is +/-1C, however when added to heating it isn't uncommon to see temperatures as much as 1.8C higher than ambient.  You should add adjustments to your code after testing in the environment you will use the sensor using a reliable thermometer.  Please do not report excessive temps as a Mongoose bug.
+For I2C, the Sensor Address is very important, the Adafruit BME280 uses address 0x77, many generic BME280's utilize 0x76.  If you are having trouble, try switching addresses or consult your datasheet.
 
-Tested using Adafruit BME280 and Adafruit Huzzah32 (Pins 22 and 23).
+It is well known that BME280's tend to self-warm and report higher than expected temperatures.  The tolerance of the BME280 tensor is +/-1C, however when added to heating it isn't uncommon to see temperatures as much as 1.8C higher than ambient.  You should add adjustments to your code after testing in the environment you will use the sensor using a reliable thermometer.  Please do not report excessive temps as a Mongoose bug.

--- a/fs/init.js
+++ b/fs/init.js
@@ -4,18 +4,32 @@
  *
  * This example demonstrates how to use mJS Arduino Adafruit_BME280
  * library API to get data from BME280 combined humidity and pressure sensor.
+ * 
+ * DON'T FORGET TO SET YOUR I2C or SPI PINS IN THE MONGOOSE CONFIG!
+ * Example:  `mos config-set i2c.scl_gpio=22 i2c.sda_gpio=23`
+ * 
+ * Please examine the README for helpful details on using this example.
  */
 
 // Load Mongoose OS API
 load('api_timer.js');
 load('api_arduino_bme280.js');
 
-// Sensors address
+// Sensors address (Usually: 0x76 or 0x77)
 let sens_addr = 0x76;
-// Initialize Adafruit_BME280 library
-let bme = Adafruit_BME280.create();
+
+// Initialize Adafruit_BME280 library using the I2C interface
+let bme = Adafruit_BME280.createI2C(sens_addr);
+
+// To use SPI instead of I2C, remove the above line and use one of the following:
+// let bme = Adafruit_BME280.createSPI(cspin)
+//      or 
+// let bme = Adafruit_BME280.createSPIFull(cspin, mosipin, misopin, sckpin)
+//   
+
+
 // Initialize the sensor
-if (bme.begin(sens_addr) === 0) {
+if (bme.begin() === 0) {
   print('Cant find a sensor');
 } else {
   // This function reads data from the BME280 sensor every 2 seconds


### PR DESCRIPTION
The current example was broken in November when the JS API of the BME280 library was changed from using a simple .create() to having different create methods for I2C, SPI, and SPI Full.  This PR fixes the example code to work.

I've also added helpful information to the README to make it easier for new Mongoose users to be successful with this sensor and reduce reliance on the forums for well known or easy to fix problems.